### PR TITLE
case Instruction::Alloca resize 수정

### DIFF
--- a/Machine/Machine.cpp
+++ b/Machine/Machine.cpp
@@ -70,9 +70,8 @@ auto execute(tuple<vector<Code>, map<string, size_t>> objectCode)->void {
       break;
     }
     case Instruction::Alloca: {
-      auto extraSize = toSize(code.operand);
-      auto currentSize = callStack.back().variables.size();
-      callStack.back().variables.resize(currentSize + extraSize);
+      auto localSize = toSize(code.operand);
+      callStack.back().variables.resize(localSize);
       break;
     }
     case Instruction::Return: {


### PR DESCRIPTION
```cpp
auto Function::generate()->void {
  functionTable[name] = codeList.size();
  auto temp = writeCode(Instruction::Alloca);
  initBlock();
  for (auto& name: parameters)
    setLocal(name);
  for (auto& node: block)
    node->generate();
  popBlock();
  patchOperand(temp, localSize);
  writeCode(Instruction::Return);
}
```
위 Generator.cpp의 Function::generate()를 보면 Instruction::Alloca의 operand는 localSize로 할당됩니다.
```cpp
  for (auto& name: parameters)
    setLocal(name);
```
위 for문에서 함수의 parameter를 순회하며 setLocal(name); 을 하고 있으므로 localSize에는 함수의 매개변수를 고려한 크기가 저장됩니다.

```cpp
case Instruction::Alloca: {
  auto extraSize = toSize(code.operand);
  auto currentSize = callStack.back().variables.size();
  callStack.back().variables.resize(currentSize + extraSize);
}
```
따라서 위 코드는 아래 코드와 같이 currentSize를 더하지 않은 toSize(code.operand) 값만으로 벡터 variables 의 resize를 수행해야 한다고 생각합니다.
```cpp
case Instruction::Alloca: {
  auto localSize = toSize(code.operand);
  callStack.back().variables.resize(localSize);
  break;
}
```